### PR TITLE
Tweak "beta" badge color

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -83,7 +83,7 @@ const Home: NextPage = () => {
                   )}
                 </div>
               </CopyToClipboard>
-              <div className="badge badge-neutral">Beta</div>
+              <div className="badge badge-warning">Beta</div>
             </div>
           </div>
 


### PR DESCRIPTION
Sorry, a nitpick, but this has been bugging me for a while haha:

![image](https://github.com/scaffold-eth/scaffoldeth.io/assets/2486142/6fe862f6-9259-431e-8a10-a72abd43cc9b)

Specially when you hover on the Docs button:

![image](https://github.com/scaffold-eth/scaffoldeth.io/assets/2486142/4571903e-dd7b-4987-aebb-48d41ef0f94b)

A lot of black buttons / badges competing with each other.

Just changed it to the "warning" color.

![image](https://github.com/scaffold-eth/scaffoldeth.io/assets/2486142/334b6f51-5ab1-45d3-a6ee-b6cbc621c241)

