### PR TITLE
Update wagmi hook example to api v2

### DIFF
--- a/packages/nextjs/components/HooksExample.tsx
+++ b/packages/nextjs/components/HooksExample.tsx
@@ -10,86 +10,34 @@ const Purple = ({ children }: { children: ReactNode }) => <span className="text-
 
 export const HooksExample = () => {
   return (
-    <div className="w-full flex-grow  bg-white rounded-2xl p-6 drop-shadow-[0px_0px_10px_rgba(139,178,241,0.50)]">
+    <div className="mt-0 lg:mt-16 w-full flex-grow  bg-white rounded-2xl p-6 drop-shadow-[0px_0px_10px_rgba(139,178,241,0.50)]">
       <div className="bg-base-300/40 w-full h-full border border-primary rounded-3xl p-4 lg:p-6 text-xs lg:text-sm  font-mono overflow-x-scroll whitespace-nowrap  lg:overflow-auto lg:whitespace-normal">
         <p className="my-3">
-          <Red>import</Red>
-          {" { "} useScaffoldWriteContract {" } "}
+          <Red>import</Red> {"{ "} useScaffoldReadContract {" } "}
           <Red>from</Red> <Cyan>&quot;~~/hooks/scaffold-eth&quot;</Cyan>;
         </p>
+        <p className="my-3">
+          <Red>import</Red> {"{ "} Address {" } "}
+          <Red>from</Red> <Cyan>&quot;~~/components/scaffold-eth&quot;</Cyan>;
+        </p>
 
         <p className="my-3">
-          <Red>const</Red>
-          {" { "}writeContractAsync: writeYourContractAsync{" } "}
+          <Red>const</Red> {"{ "}data: yourContractOwner{" } "}
           <Cyan> = </Cyan>
-          <Purple>useScaffoldWriteContract</Purple>(<Cyan dark>&quot;YourContract&quot;</Cyan>);
-        </p>
-
-        <p className="text-gray-400 my-3">
-          {"//"} To send the transaction, you can call the writeContractAsync <br className="lg:hidden" /> function
-          returned by the hook (instanced as writeYourContractAsync). <br className="lg:hidden" /> Here&apos;s an
-          example usage:
-        </p>
-
-        <p className="my-3">
-          <Red>{"<"}button</Red> className<Cyan>=&quot;btn btn-primary&quot;</Cyan> onClick<Cyan>=</Cyan>
-          {"{"}async () <Cyan>=&gt;</Cyan> {"{"}
+          <Purple>useScaffoldReadContract</Purple>({"{"}
           <br />
           <span className="inline-block ml-4">
-            try {"{"}
-            <br />
-            <span className="inline-block ml-4">
-              await writeYourContractAsync(
-              <br />
-              <span className="inline-block ml-4">
-                {"{"}
-                <br />
-                <span className="inline-block ml-4">
-                  <Cyan>functionName</Cyan>: <Cyan dark>&quot;setPurpose&quot;</Cyan>,
-                  <br />
-                  <Cyan>args</Cyan>: [<Cyan dark>&quot;The value to set&quot;</Cyan>],
-                </span>
-                <br />
-                {"}"},
-                <br />
-                {"{"}
-                <br />
-                <span className="inline-block ml-4">
-                  <Cyan>blockConfirmations</Cyan>: <Cyan dark>1</Cyan>,
-                  <br />
-                  <Purple>onBlockConfirmation</Purple>: txnReceipt <Cyan>=&gt;</Cyan> {"{"}
-                  <br />
-                  <span className="inline-block ml-4">
-                    console.<Purple>log</Purple>(<Cyan>&quot;📦 Transaction blockHash&quot;</Cyan>, &nbsp;txnReceipt.
-                    <Cyan>blockHash</Cyan>);
-                  </span>
-                  <br />
-                  {"}"}
-                </span>
-                <br />
-                {"}"}
-              </span>
-              <br />
-              );
-            </span>
-            <br />
-            {"}"} catch (e) {"{"}
-            <br />
-            <span className="inline-block ml-4">
-              console.<Purple>error</Purple>(<Cyan>&quot;Error setting purpose:&quot;</Cyan>, e);
-            </span>
-            <br />
-            {"}"}
+            <Cyan>contractName</Cyan>: <Cyan dark>&quot;YourContract&quot;</Cyan>,<br />
+            <Cyan>functionName</Cyan>: <Cyan dark>&quot;owner&quot;</Cyan>,<br />
           </span>
           <br />
-          {"}"}
-          <Red>{">"}</Red>
+          {"});"}
           <br />
-          <span className="inline-block ml-4">Send Tx</span>
-          <br />
-          <Red>
-            {"<"}/button{">"}
-          </Red>
+        </p>
+
+        <p className="my-3">
+          <Red>{"<"}Address</Red> address<Cyan>=</Cyan>
+          {"{"}yourContractOwner{"}"} <Red>/{">"}</Red>
         </p>
       </div>
     </div>

--- a/packages/nextjs/components/HooksExample.tsx
+++ b/packages/nextjs/components/HooksExample.tsx
@@ -14,46 +14,75 @@ export const HooksExample = () => {
       <div className="bg-base-300/40 w-full h-full border border-primary rounded-3xl p-4 lg:p-6 text-xs lg:text-sm  font-mono overflow-x-scroll whitespace-nowrap  lg:overflow-auto lg:whitespace-normal">
         <p className="my-3">
           <Red>import</Red>
-          {" { "} useScaffoldContractWrite {" } "}
+          {" { "} useScaffoldWriteContract {" } "}
           <Red>from</Red> <Cyan>&quot;~~/hooks/scaffold-eth&quot;</Cyan>;
         </p>
 
         <p className="my-3">
           <Red>const</Red>
-          {" { "}writeAsync, isLoading, isMining{" } "}
+          {" { "}writeContractAsync: writeYourContractAsync{" } "}
           <Cyan> = </Cyan>
-          <br />
-          <Purple>useScaffoldContractWrite</Purple>({"{"}
+          <Purple>useScaffoldWriteContract</Purple>(<Cyan dark>&quot;YourContract&quot;</Cyan>);
+        </p>
+
+        <p className="text-gray-400 my-3">
+          {"//"} To send the transaction, you can call the writeContractAsync <br className="lg:hidden" /> function
+          returned by the hook (instanced as writeYourContractAsync). <br className="lg:hidden" /> Here&apos;s an
+          example usage:
+        </p>
+
+        <p className="my-3">
+          <Red>{"<"}button</Red> className<Cyan>=&quot;btn btn-primary&quot;</Cyan> onClick<Cyan>=</Cyan>
+          {"{"}async () <Cyan>=&gt;</Cyan> {"{"}
           <br />
           <span className="inline-block ml-4">
-            <Cyan>contractName</Cyan>: <Cyan dark>&quot;YourContract&quot;</Cyan>,
-            <br />
-            <Cyan>functionName</Cyan>: <Cyan dark>&quot;setPurpose&quot;</Cyan>,
-            <br />
-            <Cyan>args</Cyan>: [<Cyan dark>&quot;The value to set&quot;</Cyan>],
-            <br />
-            <Cyan>blockConfirmation</Cyan>: <Cyan dark>1</Cyan>,
-            <br />
-            <Purple>onBlockConfirmation</Purple>: (txnReceipt) =&gt; {"{"}
+            try {"{"}
             <br />
             <span className="inline-block ml-4">
-              console.<Purple>log</Purple>(<Cyan>&quot;Transaction blockHash&quot;</Cyan>, &nbsp;txnReceipt.
-              <Cyan>blockHash</Cyan>
+              await writeYourContractAsync(
+              <br />
+              <span className="inline-block ml-4">
+                {"{"}
+                <br />
+                <span className="inline-block ml-4">
+                  <Cyan>functionName</Cyan>: <Cyan dark>&quot;setPurpose&quot;</Cyan>,
+                  <br />
+                  <Cyan>args</Cyan>: [<Cyan dark>&quot;The value to set&quot;</Cyan>],
+                </span>
+                <br />
+                {"}"},
+                <br />
+                {"{"}
+                <br />
+                <span className="inline-block ml-4">
+                  <Cyan>blockConfirmations</Cyan>: <Cyan dark>1</Cyan>,
+                  <br />
+                  <Purple>onBlockConfirmation</Purple>: txnReceipt <Cyan>=&gt;</Cyan> {"{"}
+                  <br />
+                  <span className="inline-block ml-4">
+                    console.<Purple>log</Purple>(<Cyan>&quot;📦 Transaction blockHash&quot;</Cyan>, &nbsp;txnReceipt.
+                    <Cyan>blockHash</Cyan>);
+                  </span>
+                  <br />
+                  {"}"}
+                </span>
+                <br />
+                {"}"}
+              </span>
+              <br />
               );
+            </span>
+            <br />
+            {"}"} catch (e) {"{"}
+            <br />
+            <span className="inline-block ml-4">
+              console.<Purple>error</Purple>(<Cyan>&quot;Error setting purpose:&quot;</Cyan>, e);
             </span>
             <br />
             {"}"}
           </span>
           <br />
-          {"}"});
-        </p>
-        <p className="text-gray-400 my-3">
-          {"//"} To send the transaction, you can call the writeAsync function <br className="lg:hidden" /> returned by
-          the hook. Here&apos;s an example usage:
-        </p>
-        <p className="my-3">
-          <Red>{"<"}button</Red> className<Cyan>=&quot;btn btn-primary&quot;</Cyan> onClick<Cyan>=</Cyan>
-          {"{"}() <Cyan>=&gt;</Cyan> writeAsync(){"}"}
+          {"}"}
           <Red>{">"}</Red>
           <br />
           <span className="inline-block ml-4">Send Tx</span>


### PR DESCRIPTION
## Description

Fixes #30 

This is the updated code, probably is easier to review and tweak it in markdown. I can convert it back to HTML with colors for the website.

Tried to follow old example, but maybe feels too complex with so many brackets now?

```tsx
import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";

const { writeContractAsync: writeYourContractAsync } = useScaffoldWriteContract("YourContract");

// To send the transaction, you can call the `writeContractAsync` function returned by the hook (instanced as `writeYourContractAsync`). Here's an example usage:

<button
  className="btn btn-primary"
  onClick={async () => {
    try {
      await writeYourContractAsync(
        {
          functionName: "setPurpose",
          args: ["The value to set"],
        },
        {
          blockConfirmations: 1,
          onBlockConfirmation: txnReceipt => {
            console.log("📦 Transaction blockHash", txnReceipt.blockHash);
          },
        },
      );
    } catch (e) {
      console.error("Error setting purpose:", e);
    }
  }}
>
  Send Tx
</button>
```