### PR TITLE
Remove clone command + Highlight npx command

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -189,7 +189,7 @@ const Home: NextPage = () => {
                   }, 800);
                 }}
               >
-                <div className="flex items-center justify-between border-2 border-gray-300 rounded-xl px-3 py-2 text-xs sm:text-sm">
+                <div className="flex items-center justify-between border-2 border-primary rounded-xl px-3 py-2 text-xs sm:text-sm">
                   <p className="m-0 mr-2">npx create-eth@latest -e gitHubUsername/repoName</p>
                   {extensionCommandCopied ? (
                     <CheckCircleIcon


### PR DESCRIPTION
As we discussed yesterday, we are moving away from SE-2 clone method. The first step is to remove it from the docs / READMEs / etc.

I removed it here + highlighted the npx command a bit.

before
![image](https://github.com/user-attachments/assets/6d9d1002-d5dd-4f2f-bf4d-5be772d4e383)

after
![image](https://github.com/user-attachments/assets/a1d835be-9cb3-4d5f-b0fd-922e8ba21d4a)

--

What do you all think? Happy to tweak

We can also wait to merge if we want to sync with other PRs.

Related https://github.com/scaffold-eth/scaffold-eth-2/pull/993
