### PR TITLE
Filter SRE challenges extensions on the extensions page

### DIFF
--- a/packages/nextjs/pages/extensions.tsx
+++ b/packages/nextjs/pages/extensions.tsx
@@ -164,10 +164,15 @@ export const getStaticProps: GetStaticProps<ExtensionsListProps> = async () => {
         };
       });
 
+    // Filter out SpeedRunEthereum challenges extensions
+    const curatedExtensionsFiltered = curatedExtensions.filter(
+      ext => !ext.github.startsWith("https://github.com/scaffold-eth/se-2-challenges"),
+    );
+
     return {
       props: {
         thirdPartyExtensions,
-        curatedExtensions,
+        curatedExtensions: curatedExtensionsFiltered,
       },
       // Revalidate every 6 hours (21600 seconds)
       revalidate: 21600,


### PR DESCRIPTION
We need to merge https://github.com/scaffold-eth/create-eth/pull/198 first to test it properly, but I tested it by changing where the code gets the extensions JSON file from local using the same JSON file with the challenges extensions.

Closes #45 