### PR TITLE
add delegation toolkit extension by metamask

### DIFF
--- a/packages/nextjs/components/ExtensionCard.tsx
+++ b/packages/nextjs/components/ExtensionCard.tsx
@@ -55,16 +55,18 @@ export const ExtensionCard = ({ extension, isCurated }: { extension: Extension; 
           {isCurated ? (
             <div className="badge badge-secondary p-3">Curated</div>
           ) : (
-            <div>
-              <Address address={extension.builder} disableAddressLink />
-              {extension.coBuilders && extension.coBuilders.length > 0 && (
-                <div className="text-sm mt-2">
-                  {extension.coBuilders.map((coBuilder, index) => (
-                    <Address key={index} address={coBuilder} disableAddressLink />
-                  ))}
-                </div>
-              )}
-            </div>
+            extension.builder && (
+              <div>
+                <Address address={extension.builder} disableAddressLink />
+                {extension.coBuilders && extension.coBuilders.length > 0 && (
+                  <div className="text-sm mt-2">
+                    {extension.coBuilders.map((coBuilder, index) => (
+                      <Address key={index} address={coBuilder} disableAddressLink />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
           )}
         </div>
         <p

--- a/packages/nextjs/pages/extensions.tsx
+++ b/packages/nextjs/pages/extensions.tsx
@@ -13,8 +13,8 @@ type Extension = {
   description: string;
   github: string;
   installCommand: string;
-  builder: string;
-  coBuilders: string[];
+  builder?: string;
+  coBuilders?: string[];
   youtube?: string;
 };
 
@@ -28,6 +28,15 @@ type CuratedExtensionResponse = {
   name?: string; // human redable name, if not present we default to branch or extensionFlagValue on UI
 }[];
 
+// TODO: Remove this and find a better way to allow extension submission from different orgs.
+const metamaskExtension: Extension = {
+  name: "Delegation Toolkit Extension",
+  description:
+    "The MetaMask Delegation Toolkit is a Viem-based collection of tools for integrating embedded smart accounts, known as `MetaMaskSmartAccount`, into dapps. Developers can create and manage delegator accounts that delegate specific permissions, such as spending limits or time-based access, to other accounts. This extension demonstrates the end-to-end flow for initializing a MetaMask Smart Account, generating and signing a delegation, and redeeming the delegation according to [ERC-7710](https://eips.ethereum.org/EIPS/eip-7710) specifications. ",
+  github: "https://github.com/MetaMask/gator-extension",
+  installCommand: "npx create-eth@latest -e metamask/gator-extension",
+};
+
 interface ExtensionsListProps {
   thirdPartyExtensions: Extension[];
   curatedExtensions: Extension[];
@@ -36,7 +45,7 @@ interface ExtensionsListProps {
 const ExtensionsList: NextPage<ExtensionsListProps> = ({ thirdPartyExtensions, curatedExtensions }) => {
   const [searchQuery, setSearchQuery] = useState("");
 
-  const allExtensions = [...curatedExtensions, ...thirdPartyExtensions];
+  const allExtensions = [...curatedExtensions, metamaskExtension, ...thirdPartyExtensions];
 
   const filteredExtensions = allExtensions.filter(extension => {
     if (searchQuery.length < 3) return true;


### PR DESCRIPTION
## Description 

Currently, the sources of extension's is BG v3.5 API (to be discontinued) and extension.json file (curated extension) in create-eth. 

For now hardcoding the extension, but yeah we need to figure out better way to list extensions of this types (where builder is org) 

<img width="450" alt="image" src="https://github.com/user-attachments/assets/88d2cc4b-e522-435e-8cbc-55bb08c43e62" />

--- 

### Probable future solution: 

https://github.com/scaffold-eth/scaffoldeth.io/blob/main/packages/nextjs/pages/extensions.tsx#L172-L179 

Here we could have third array called as "orgsExtensions".  Where people from that organization can create a PR in this repo updating that variable. 


