### PR TITLE
fix: _blanck typo in url

### DIFF
--- a/packages/nextjs/components/TrackedLink.tsx
+++ b/packages/nextjs/components/TrackedLink.tsx
@@ -15,7 +15,7 @@ export default function TrackedLink({ id, href, className, children }: TrackedLi
   return (
     <a
       href={href}
-      target="_blanck"
+      target="_blank"
       rel="noreferrer"
       className={className}
       onClick={() => plausible("click", { props: { id } })}


### PR DESCRIPTION
## Description

I was curious about the `llms-full.txt` link under the "Docs" call to action on your homepage and thought it was a pretty cool idea which I should replicate on [Juno](https://juno.build). While I had a quick look at the rendered code, I noticed a small typo in the link attribute: `_blanck` instead of `_blank`. So, here's a small PR to fix that.
