### PR TITLE
add envio extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ Work in progress.
 
 Before you begin, you need to install the following tools:
 
-- [Node (v18 LTS)](https://nodejs.org/en/download/)
+- [Node (>= v22.18.0)](https://nodejs.org/en/download/)
 - Yarn ([v1](https://classic.yarnpkg.com/en/docs/install/) or [v2+](https://yarnpkg.com/getting-started/install))
 - [Git](https://git-scm.com/downloads)
 
 ## Quickstart
-
 
 1. Clone this repo & install dependencies
 

--- a/packages/nextjs/data/orgsExtensions.tsx
+++ b/packages/nextjs/data/orgsExtensions.tsx
@@ -1,0 +1,19 @@
+import { Extension } from "~~/pages/extensions";
+
+export const orgsExtensions: Extension[] = [
+  {
+    name: "Delegation Toolkit Extension",
+    description:
+      "The MetaMask Delegation Toolkit is a Viem-based collection of tools for integrating embedded smart accounts, known as MetaMaskSmartAccount, into dapps. Developers can create and manage delegator accounts that delegate specific permissions, such as spending limits or time-based access, to other accounts. This extension demonstrates the end-to-end flow for initializing a MetaMask Smart Account, generating and signing a delegation, and redeeming the delegation according to [ERC-7710](https://eips.ethereum.org/EIPS/eip-7710) specifications. ",
+    github: "https://github.com/MetaMask/gator-extension",
+    installCommand: "npx create-eth@latest -e metamask/gator-extension",
+  },
+
+  {
+    name: "Envio Indexer",
+    description:
+      "This extension adds automatic Envio indexer generation to your Scaffold-ETH 2 project, allowing you to index all your deployed smart contracts and query their data through a GraphQL API",
+    github: "https://github.com/enviodev/scaffold-eth-2-extension",
+    installCommand: "npx create-eth@latest -e envio/scaffold-eth-2-extension",
+  },
+];

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
-    "@types/node": "^17.0.35",
+    "@types/node": "^24.5.2",
     "@types/react": "^18.0.9",
     "@types/react-blockies": "^1.4.1",
     "@types/react-copy-to-clipboard": "^5.0.4",

--- a/packages/nextjs/pages/extensions.tsx
+++ b/packages/nextjs/pages/extensions.tsx
@@ -5,10 +5,11 @@ import type { GetStaticProps, NextPage } from "next";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
 import { ExtensionCard } from "~~/components/ExtensionCard";
 import { MetaHeader } from "~~/components/MetaHeader";
+import { orgsExtensions } from "~~/data/orgsExtensions";
 
 const BGAPP_API_URL = process.env.BGAPP_API_URL;
 
-type Extension = {
+export type Extension = {
   name: string;
   description: string;
   github: string;
@@ -28,15 +29,6 @@ type CuratedExtensionResponse = {
   name?: string; // human redable name, if not present we default to branch or extensionFlagValue on UI
 }[];
 
-// TODO: Remove this and find a better way to allow extension submission from different orgs.
-const metamaskExtension: Extension = {
-  name: "Delegation Toolkit Extension",
-  description:
-    "The MetaMask Delegation Toolkit is a Viem-based collection of tools for integrating embedded smart accounts, known as `MetaMaskSmartAccount`, into dapps. Developers can create and manage delegator accounts that delegate specific permissions, such as spending limits or time-based access, to other accounts. This extension demonstrates the end-to-end flow for initializing a MetaMask Smart Account, generating and signing a delegation, and redeeming the delegation according to [ERC-7710](https://eips.ethereum.org/EIPS/eip-7710) specifications. ",
-  github: "https://github.com/MetaMask/gator-extension",
-  installCommand: "npx create-eth@latest -e metamask/gator-extension",
-};
-
 interface ExtensionsListProps {
   thirdPartyExtensions: Extension[];
   curatedExtensions: Extension[];
@@ -45,7 +37,7 @@ interface ExtensionsListProps {
 const ExtensionsList: NextPage<ExtensionsListProps> = ({ thirdPartyExtensions, curatedExtensions }) => {
   const [searchQuery, setSearchQuery] = useState("");
 
-  const allExtensions = [...curatedExtensions, metamaskExtension, ...thirdPartyExtensions];
+  const allExtensions = [...curatedExtensions, ...orgsExtensions, ...thirdPartyExtensions];
 
   const filteredExtensions = allExtensions.filter(extension => {
     if (searchQuery.length < 3) return true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,7 +1118,7 @@ __metadata:
     "@heroicons/react": ^2.0.11
     "@rainbow-me/rainbowkit": ^1.0.4
     "@trivago/prettier-plugin-sort-imports": ^4.1.1
-    "@types/node": ^17.0.35
+    "@types/node": ^24.5.2
     "@types/react": ^18.0.9
     "@types/react-blockies": ^1.4.1
     "@types/react-copy-to-clipboard": ^5.0.4
@@ -1548,10 +1548,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^17.0.35":
-  version: 17.0.45
-  resolution: "@types/node@npm:17.0.45"
-  checksum: aa04366b9103b7d6cfd6b2ef64182e0eaa7d4462c3f817618486ea0422984c51fc69fd0d436eae6c9e696ddfdbec9ccaa27a917f7c2e8c75c5d57827fe3d95e8
+"@types/node@npm:^24.5.2":
+  version: 24.5.2
+  resolution: "@types/node@npm:24.5.2"
+  dependencies:
+    undici-types: ~7.12.0
+  checksum: 5d859c117a3e15e2e7cca429ba2db9b7c5ef167eb6386ab3db9f9aad7f705baee45957ad11d6c3d7514dc189ee9ec311905944dfbe9823497ad80a9f15add048
   languageName: node
   linkType: hard
 
@@ -8381,6 +8383,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.12.0":
+  version: 7.12.0
+  resolution: "undici-types@npm:7.12.0"
+  checksum: 4ad2770b92835757eee6416e8518972d83fc77286c11af81d368a55578d9e4f7ab1b8a3b13c304b0e25a400583e66f3c58464a051f8b5c801ab5d092da13903e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Adds Envio extension: https://github.com/enviodev/scaffold-eth-2-extension 

--- 

I think we need to discuss, what's the best way to handle this so that we don't need to hardcode the stuff in website repo itself. 

For now I have just created the `orgsExtensions` file where we can add other orgs extension 

--- 

Also updated the node version since vercel discontinued the v18 from sept 01