### PR TITLE
Add SE2 projects stats below intro video

### DIFF
--- a/packages/nextjs/components/SE2Stats.tsx
+++ b/packages/nextjs/components/SE2Stats.tsx
@@ -38,9 +38,9 @@ const ForkIcon = () => (
 
 export const SE2Stats = ({ stats }: { stats: SE2StatsData | null }) => {
   return (
-    <div className="w-full max-w-xl mx-auto pt-10">
-      <p className="text-lg font-light text-center mb-3 tracking-wide">Join thousands of builders</p>
-      <a href="https://se2-projects.vercel.app/" target="_blank" rel="noopener noreferrer" className="block group">
+    <div className={`w-full max-w-xl mx-auto -mt-36 lg:-mt-[34rem] mb-12 lg:mb-20`}>
+      <p className="text-lg font-light text-center mb-3 tracking-wide">Trusted by a big community of builders</p>
+      <a href="http://projects.scaffoldeth.io/" target="_blank" rel="noopener noreferrer" className="block group">
         <div className="bg-base-100/80 backdrop-blur-sm border border-base-300/60 rounded-2xl shadow-sm hover:shadow-md hover:border-base-300 transition-all duration-300">
           {/* Stats grid with dividers */}
           <div className="grid grid-cols-3 divide-x divide-base-300/50">

--- a/packages/nextjs/components/SE2Stats.tsx
+++ b/packages/nextjs/components/SE2Stats.tsx
@@ -1,0 +1,69 @@
+import { CodeBracketIcon, StarIcon } from "@heroicons/react/24/outline";
+
+export type SE2StatsData = {
+  totalRepositories: number;
+  totalStars: number;
+  totalForks: number;
+};
+
+type StatItemProps = {
+  value: number | null;
+  label: string;
+  icon: React.ReactNode;
+};
+
+const formatNumber = (num: number | null): string => {
+  if (num === null) return "-";
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(1).replace(/\.0$/, "")}k+`;
+  }
+  return num.toString();
+};
+
+const StatItem = ({ value, label, icon }: StatItemProps) => (
+  <div className="flex flex-col items-center justify-center gap-0.5 sm:gap-1.5 py-3 sm:py-4 px-1.5 sm:px-3">
+    <div className="flex items-center gap-1 sm:gap-2">
+      <span className="text-primary/70">{icon}</span>
+      <span className="text-lg sm:text-2xl font-bold text-base-content">{formatNumber(value)}</span>
+    </div>
+    <span className="text-[9px] sm:text-[11px] text-base-content/60 font-medium uppercase tracking-wider">{label}</span>
+  </div>
+);
+
+const ForkIcon = () => (
+  <svg className="h-4 w-4 sm:h-5 sm:w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M7 5a2 2 0 100-4 2 2 0 000 4zM7 21a2 2 0 100-4 2 2 0 000 4zM17 9a2 2 0 100-4 2 2 0 000 4zM7 5v12M7 17c0-4 10-4 10-10" />
+  </svg>
+);
+
+export const SE2Stats = ({ stats }: { stats: SE2StatsData | null }) => {
+  return (
+    <div className="w-full max-w-xl mx-auto pt-10">
+      <p className="text-lg font-light text-center mb-3 tracking-wide">Join thousands of builders</p>
+      <a href="https://se2-projects.vercel.app/" target="_blank" rel="noopener noreferrer" className="block group">
+        <div className="bg-base-100/80 backdrop-blur-sm border border-base-300/60 rounded-2xl shadow-sm hover:shadow-md hover:border-base-300 transition-all duration-300">
+          {/* Stats grid with dividers */}
+          <div className="grid grid-cols-3 divide-x divide-base-300/50">
+            <StatItem
+              value={stats?.totalRepositories ?? null}
+              label="Projects Built"
+              icon={<CodeBracketIcon className="h-4 w-4 sm:h-5 sm:w-5" />}
+            />
+            <StatItem
+              value={stats?.totalStars ?? null}
+              label="GitHub Stars"
+              icon={<StarIcon className="h-4 w-4 sm:h-5 sm:w-5" />}
+            />
+            <StatItem value={stats?.totalForks ?? null} label="Forks" icon={<ForkIcon />} />
+          </div>
+          {/* Footer link */}
+          <div className="border-t border-base-300/50 py-2 text-center">
+            <span className="text-xs text-base-content/50 group-hover:text-primary transition-colors">
+              View all projects →
+            </span>
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+};

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -40,7 +40,7 @@ const Home: NextPage<HomeProps> = ({ se2Stats }) => {
       <MetaHeader />
       {/* Hero section  */}
       <div
-        className="flex flex-col items-center pt-8 pb-20 gap-12 md:gap-20 lg:pb-56"
+        className="flex flex-col items-center pt-8 pb-20 gap-12 md:gap-20 lg:pb-[29rem]"
         style={{
           backgroundImage: `url(/assets/heroPattern.svg)`,
           backgroundRepeat: "repeat",
@@ -126,11 +126,13 @@ const Home: NextPage<HomeProps> = ({ se2Stats }) => {
                 <ExtensionCardMini key={index} extension={extension} />
               ))}
             </div>
-            <p className="m-auto text-center lg:text-left lg:mx-0 max-w-[400px] lg:max-w-none lg:pr-6 link">
-              <TrackedLink id="ExtensionsListHero" href="/extensions">
-                Explore all the extensions
-              </TrackedLink>
-            </p>
+            <div className="w-full max-w-5xl flex justify-end">
+              <p className="m-0 text-center lg:text-left link">
+                <TrackedLink id="ExtensionsListHero" href="/extensions">
+                  Explore all the extensions
+                </TrackedLink>
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -138,7 +140,8 @@ const Home: NextPage<HomeProps> = ({ se2Stats }) => {
       {/* SE2 Video and Stats */}
       <div className="bg-base-300/20">
         <div className="container max-w-[90%] lg:max-w-5xl m-auto pt-16 pb-8 lg:pt-20 lg:pb-10">
-          <div className="-mt-32 lg:-mt-72 w-full rounded-2xl overflow-hidden shadow-lg shadow-primary">
+          <SE2Stats stats={se2Stats} />
+          <div className="w-full rounded-2xl overflow-hidden shadow-lg shadow-primary">
             <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
               <iframe
                 src="https://www.youtube.com/embed/AUwYGRkxm_8"
@@ -149,7 +152,6 @@ const Home: NextPage<HomeProps> = ({ se2Stats }) => {
               ></iframe>
             </div>
           </div>
-          <SE2Stats stats={se2Stats} />
         </div>
       </div>
 
@@ -370,7 +372,7 @@ const Home: NextPage<HomeProps> = ({ se2Stats }) => {
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   try {
-    const res = await fetch("https://se2-projects.vercel.app/api/repositories/stats");
+    const res = await fetch("http://projects.scaffoldeth.io/api/repositories/stats");
     const data = await res.json();
     return {
       props: {

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -1,14 +1,19 @@
 import { useState } from "react";
 import Image from "next/image";
-import type { NextPage } from "next";
+import type { GetStaticProps, NextPage } from "next";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { ExtensionCardMini } from "~~/components/ExtensionCardMini";
 import { HooksExample } from "~~/components/HooksExample";
 import { MetaHeader } from "~~/components/MetaHeader";
+import { SE2Stats, SE2StatsData } from "~~/components/SE2Stats";
 import TrackedLink from "~~/components/TrackedLink";
 
-const Home: NextPage = () => {
+type HomeProps = {
+  se2Stats: SE2StatsData | null;
+};
+
+const Home: NextPage<HomeProps> = ({ se2Stats }) => {
   const [npxCommandCopied, setNpxCommandCopied] = useState(false);
   const [extensionCommandCopied, setExtensionCommandCopied] = useState(false);
 
@@ -35,7 +40,7 @@ const Home: NextPage = () => {
       <MetaHeader />
       {/* Hero section  */}
       <div
-        className="flex flex-col items-center pt-8 pb-20 gap-12 md:gap-20 lg:pb-64"
+        className="flex flex-col items-center pt-8 pb-20 gap-12 md:gap-20 lg:pb-56"
         style={{
           backgroundImage: `url(/assets/heroPattern.svg)`,
           backgroundRepeat: "repeat",
@@ -129,8 +134,10 @@ const Home: NextPage = () => {
           </div>
         </div>
       </div>
+
+      {/* SE2 Video and Stats */}
       <div className="bg-base-300/20">
-        <div className="container max-w-[90%] lg:max-w-5xl m-auto pt-16 pb-8 lg:py-20">
+        <div className="container max-w-[90%] lg:max-w-5xl m-auto pt-16 pb-8 lg:pt-20 lg:pb-10">
           <div className="-mt-32 lg:-mt-72 w-full rounded-2xl overflow-hidden shadow-lg shadow-primary">
             <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
               <iframe
@@ -142,6 +149,7 @@ const Home: NextPage = () => {
               ></iframe>
             </div>
           </div>
+          <SE2Stats stats={se2Stats} />
         </div>
       </div>
 
@@ -358,6 +366,28 @@ const Home: NextPage = () => {
       </div>
     </>
   );
+};
+
+export const getStaticProps: GetStaticProps<HomeProps> = async () => {
+  try {
+    const res = await fetch("https://se2-projects.vercel.app/api/repositories/stats");
+    const data = await res.json();
+    return {
+      props: {
+        se2Stats: {
+          totalRepositories: data.totalRepos ?? 0,
+          totalStars: data.totals?.totalStars ?? 0,
+          totalForks: data.totals?.totalForks ?? 0,
+        },
+      },
+      revalidate: 21600, // Revalidate every 6 hours
+    };
+  } catch {
+    return {
+      props: { se2Stats: null },
+      revalidate: 60, // Retry sooner on error
+    };
+  }
 };
 
 export default Home;


### PR DESCRIPTION
Adds a new stats component showing Scaffold-ETH 2 repositories metrics (projects built, GitHub stars, forks) fetched from the se2-projects API.

Changes:
- New SE2Stats component displaying repositories metrics
- Stats are fetched via getStaticProps (revalidates every 6 hours)
- Positioned below the intro video for better content flow
- Links to se2-projects.vercel.app for full project stats + repository list

Also reduced the spacing before the video so it shows a bit above the fold on big screens, trying to get more views or scrolls down. Feel free to undo!