### PR TITLE
add skills page

### DIFF
--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -11,14 +11,6 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
-  async rewrites() {
-    return [
-      {
-        source: "/skill",
-        destination: "/skill.md",
-      },
-    ];
-  },
 };
 
 module.exports = withPlausibleProxy()(nextConfig);

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -11,6 +11,14 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
+  async rewrites() {
+    return [
+      {
+        source: "/skill",
+        destination: "/skill.md",
+      },
+    ];
+  },
 };
 
 module.exports = withPlausibleProxy()(nextConfig);

--- a/packages/nextjs/public/skill.md
+++ b/packages/nextjs/public/skill.md
@@ -1,0 +1,51 @@
+---
+name: ethereum-app-builder
+description: "Scaffold and build Ethereum dApps using create-eth (Scaffold-ETH 2). Use when the user wants to: build an Ethereum app, create a dApp, start a web3 project, use Scaffold-ETH or create-eth, build something onchain, deploy a smart contract, deploy a smart contract with a frontend, or scaffold a full-stack blockchain application."
+---
+
+# Ethereum App Builder
+
+Scaffold full-stack Ethereum dApps using create-eth (Scaffold-ETH 2). Guide the user through project setup, scaffold it, then build out their idea.
+
+## Step 1: Project Name
+
+Ask what the user wants to build and derive a kebab-case project name from their description (e.g., "voting app" -> `voting-app`).
+
+## Step 2: Framework
+
+Ask which Solidity framework they prefer.
+
+- **Hardhat** -- JavaScript-based, beginner-friendly
+- **Foundry** (default) -- Rust-based, faster compilation, Solidity-native tests
+
+If no preference, use foundry.
+
+## Step 3: Scaffold
+
+```bash
+npx create-eth@latest -s <hardhat|foundry> <project-name>
+```
+
+## Step 4: Build the User's Idea
+
+Read `<project-name>/AGENTS.md` -- this is the source of truth for the project's structure, patterns, hooks, components, and conventions. Always read it before writing any code.
+
+Check the [create-eth-extensions skills](https://github.com/scaffold-eth/create-eth-extensions) repository for reference skills that cover specialized Ethereum needs (event indexing, token standards, etc.). If any skill is relevant to what the user is building, use it during implementation.
+
+Available reference skills:
+
+- **[Ponder](https://github.com/scaffold-eth/create-eth-extensions/blob/ponder-extension-to-skills/skills/ponder/SKILL.md)** -- Blockchain event indexing with Ponder, including SE-2 integration, schema setup, and GraphQL API
+
+Using `AGENTS.md` and any relevant reference skills as your guide, implement the user's idea -- contracts, frontend, integrations. Make sure it all compiles.
+
+## Step 5: Quickstart
+
+Guide the user through running the app. Three terminals:
+
+```bash
+yarn chain          # local chain
+yarn deploy         # deploy contracts
+yarn start          # frontend at http://localhost:3000
+```
+
+If a reference skill added extra services (e.g., `yarn ponder:dev` for Ponder), include those in the quickstart too.

--- a/packages/nextjs/public/skill.md
+++ b/packages/nextjs/public/skill.md
@@ -30,9 +30,9 @@ npx create-eth@latest -s <hardhat|foundry> <project-name>
 
 Read `<project-name>/AGENTS.md` -- this is the source of truth for the project's structure, patterns, hooks, components, and conventions. Always read it before writing any code.
 
-Check the [create-eth-extensions skills](https://github.com/scaffold-eth/create-eth-extensions) repository for reference skills that cover specialized Ethereum needs (event indexing, token standards, etc.). If any skill is relevant to what the user is building, use it during implementation.
+Check the [create-eth-extensions](https://github.com/scaffold-eth/create-eth-extensions) repository for reference skills that cover specialized Ethereum needs (event indexing, token standards, etc.). The repo follows a branch-based system -- any branch with `*skill` in its name contains a skill, and the actual skill file is located at `skills/<name>/SKILL.md` within that branch. If any skill is relevant to what the user is building, fetch and use it during implementation.
 
-Available reference skills:
+Known reference skills:
 
 - **[Ponder](https://github.com/scaffold-eth/create-eth-extensions/blob/ponder-extension-to-skills/skills/ponder/SKILL.md)** -- Blockchain event indexing with Ponder, including SE-2 integration, schema setup, and GraphQL API
 

--- a/packages/nextjs/public/skill.md
+++ b/packages/nextjs/public/skill.md
@@ -3,7 +3,7 @@ name: ethereum-app-builder
 description: "Scaffold and build Ethereum dApps using create-eth (Scaffold-ETH 2). Use when the user wants to: build an Ethereum app, create a dApp, start a web3 project, use Scaffold-ETH or create-eth, build something onchain, deploy a smart contract, deploy a smart contract with a frontend, or scaffold a full-stack blockchain application."
 ---
 
-## Ethereum App Builder
+# Ethereum App Builder
 
 Scaffold full-stack Ethereum dApps using create-eth (Scaffold-ETH 2). Guide the user through project setup, scaffold it, then build out their idea.
 

--- a/packages/nextjs/public/skill.md
+++ b/packages/nextjs/public/skill.md
@@ -3,30 +3,22 @@ name: ethereum-app-builder
 description: "Scaffold and build Ethereum dApps using create-eth (Scaffold-ETH 2). Use when the user wants to: build an Ethereum app, create a dApp, start a web3 project, use Scaffold-ETH or create-eth, build something onchain, deploy a smart contract, deploy a smart contract with a frontend, or scaffold a full-stack blockchain application."
 ---
 
-# Ethereum App Builder
+## Ethereum App Builder
 
 Scaffold full-stack Ethereum dApps using create-eth (Scaffold-ETH 2). Guide the user through project setup, scaffold it, then build out their idea.
 
-## Step 1: Project Name
+## Step 1: Install Scaffold-ETH 2
 
-Ask what the user wants to build and derive a kebab-case project name from their description (e.g., "voting app" -> `voting-app`).
-
-## Step 2: Framework
-
-Ask which Solidity framework they prefer.
-
-- **Hardhat** -- JavaScript-based, beginner-friendly
-- **Foundry** (default) -- Rust-based, faster compilation, Solidity-native tests
-
-If no preference, use foundry.
-
-## Step 3: Scaffold
+To set up Scaffold-ETH 2 locally, you can run this command:
 
 ```bash
 npx create-eth@latest -s <hardhat|foundry> <project-name>
 ```
 
-## Step 4: Build the User's Idea
+- If no preference by the user, use Foundry.
+- For the project-name, use a kebab-case
+
+## Step 2: Build the User's Idea
 
 Read `<project-name>/AGENTS.md` -- this is the source of truth for the project's structure, patterns, hooks, components, and conventions. Always read it before writing any code.
 
@@ -34,18 +26,6 @@ Check the [create-eth-extensions](https://github.com/scaffold-eth/create-eth-ext
 
 Known reference skills:
 
-- **[Ponder](https://github.com/scaffold-eth/create-eth-extensions/blob/ponder-extension-to-skills/skills/ponder/SKILL.md)** -- Blockchain event indexing with Ponder, including SE-2 integration, schema setup, and GraphQL API
+- [**Ponder**](https://github.com/scaffold-eth/create-eth-extensions/blob/ponder-extension-to-skills/skills/ponder/SKILL.md) -- Blockchain event indexing with Ponder, including SE-2 integration, schema setup, and GraphQL API
 
 Using `AGENTS.md` and any relevant reference skills as your guide, implement the user's idea -- contracts, frontend, integrations. Make sure it all compiles.
-
-## Step 5: Quickstart
-
-Guide the user through running the app. Three terminals:
-
-```bash
-yarn chain          # local chain
-yarn deploy         # deploy contracts
-yarn start          # frontend at http://localhost:3000
-```
-
-If a reference skill added extra services (e.g., `yarn ponder:dev` for Ponder), include those in the quickstart too.


### PR DESCRIPTION
## Description

Adds a `SKILL.md` file served at the `/skill` route on scaffoldeth.io.
The skill walks through:
1. Asking the user what they want to build and deriving a project name
2. Choosing a Solidity framework (Hardhat or Foundry)
3. Scaffolding the project with `npx create-eth@latest`
4. Building out the user's idea using `AGENTS.md` and reference skills
5. Guiding the user through the quickstart (`yarn chain`, `yarn deploy`, `yarn start`)

It points to the [create-eth-extensions](https://github.com/scaffold-eth/create-eth-extensions) repo for reference skills (e.g., [Ponder skill](https://github.com/scaffold-eth/create-eth-extensions/blob/ponder-extension-to-skills/skills/ponder/SKILL.md) for blockchain event indexing). In future we would probably hosting the skills on this repo. 


