### PR TITLE
Add canonical URLs, llms.txt, and stable social image URLs

### DIFF
--- a/packages/nextjs/components/MetaHeader.tsx
+++ b/packages/nextjs/components/MetaHeader.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { SITE_URL } from "~~/utils/site";
 
 type MetaHeaderProps = {
   title?: string;
@@ -9,8 +11,7 @@ type MetaHeaderProps = {
   children?: React.ReactNode;
 };
 
-// Images must have an absolute path to work properly on Twitter.
-// We try to get it dynamically from Vercel, but we default to relative path.
+// The frame endpoint is served by whichever deployment renders the page.
 const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/` : "/";
 
 export const MetaHeader = ({
@@ -20,8 +21,12 @@ export const MetaHeader = ({
   twitterCard = "summary_large_image",
   children,
 }: MetaHeaderProps) => {
-  const imageUrl = baseUrl + image;
-  const twitterImageUrl = baseUrl + "twitterThumbnail.png";
+  const { asPath } = useRouter();
+  // Social images need an absolute URL that stays valid across deploys.
+  const imageUrl = `${SITE_URL}/${image}`;
+  const twitterImageUrl = `${SITE_URL}/twitterThumbnail.png`;
+  // Query strings and hashes are dropped so each page has one canonical address.
+  const canonicalUrl = SITE_URL + asPath.split(/[?#]/)[0];
 
   return (
     <Head>
@@ -60,6 +65,7 @@ export const MetaHeader = ({
         </>
       )}
       {twitterCard && <meta name="twitter:card" content={twitterCard} />}
+      <link rel="canonical" href={canonicalUrl} />
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
       {children}
     </Head>

--- a/packages/nextjs/public/llms.txt
+++ b/packages/nextjs/public/llms.txt
@@ -1,0 +1,21 @@
+# Scaffold-ETH 2
+
+> Open-source toolkit for building decentralized applications on Ethereum. Contracts, a
+> frontend and deploy scripts in one repo, with a debug UI that adapts to your contracts as
+> you edit them. Built using NextJS, RainbowKit, Foundry/Hardhat, Wagmi, Viem and TypeScript.
+> Start a project with `npx create-eth@latest`.
+
+## Pages
+
+- [Scaffold-ETH 2](https://scaffoldeth.io/): What the toolkit includes, its stack, and how to start a project.
+- [Extensions](https://scaffoldeth.io/extensions): Add-ons installed at project creation with `npx create-eth@latest -e <name>`.
+
+## Documentation
+
+- [Docs](https://docs.scaffoldeth.io/): Installation, components, hooks, recipes, deploying and extensions.
+- [Docs index for agents](https://docs.scaffoldeth.io/llms.txt): The complete index, and the authority on documentation. This file only covers scaffoldeth.io.
+- [SKILL.md](https://docs.scaffoldeth.io/SKILL.md): Entry point AI agents use to scaffold a new project.
+
+## Source
+
+- [scaffold-eth/scaffold-eth-2](https://github.com/scaffold-eth/scaffold-eth-2): The toolkit repository.

--- a/packages/nextjs/utils/site.ts
+++ b/packages/nextjs/utils/site.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = "https://scaffoldeth.io";


### PR DESCRIPTION
## Summary

Three small changes with one thing in common: every page should have one address, and that
address should be the production one.

| | Now | After |
| --- | --- | --- |
| `rel=canonical` | absent on both pages | `https://scaffoldeth.io/` and `/extensions` |
| `og:image` | `https://scaffoldeth-5pljm1j2t-buidlguidldao.vercel.app/og-image.png` | `https://scaffoldeth.io/og-image.png` |
| `/llms.txt` | 404 | short entry point that routes to the docs |

## Canonical

Neither page emits one, so any URL carrying a query string is a separate address as far as a
crawler is concerned. The Farcaster frame posts to `/?id=1`, which is exactly that case.
`MetaHeader` now emits a canonical for whatever page renders it, from the path with query and
hash stripped.

## Social images

`og:image` and `twitter:image` were built from `NEXT_PUBLIC_VERCEL_URL`, which is the immutable
deployment host rather than the production domain. The current URL resolves, so nothing is
broken today, but it changes with every production deploy and it advertises a `vercel.app`
host. They now use the production origin.

The frame `post_url` deliberately stays on `baseUrl`, since that endpoint belongs to whichever
deployment served the page. Worth knowing: `fc:frame:image` follows the image URL, so frames on
preview deploys will now show the production image.

## llms.txt

The docs site serves one, the landing page does not yet, and this is the first place an agent
resolving "scaffold-eth" tends to land. This adds a short entry point describing the toolkit
and routing on to the docs, the docs' own `llms.txt`, `SKILL.md`, and the repo. It defers to
the docs index rather than competing with it. The page already links `SKILL.md` next to Docs
(#60), so this is the same route without parsing the page.

No `robots.txt` or `sitemap.xml` here: absence of robots.txt already means allow-all, and both
pages are linked from the homepage. Happy to add them if you want them for completeness.

## How to test

```bash
yarn install && yarn start
curl -s localhost:3000/           | grep -E 'canonical|og:image'
curl -s localhost:3000/extensions | grep canonical
curl -s "localhost:3000/?id=1"    | grep canonical   # collapses to /
curl -s localhost:3000/llms.txt
```

`yarn next:lint` and `yarn next:check-types` both pass.
